### PR TITLE
feat: add option useStorybook for mdx2 files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export function load(app: Application) {
     help: '[Markdown Plugin] The file name of the entry document.',
     name: 'entryDocument',
     type: ParameterType.String,
-    defaultValue: 'README.mdx',
+    defaultValue: 'README.md',
   });
 
   app.options.addDeclaration({
@@ -82,7 +82,7 @@ export function load(app: Application) {
   });
 
   app.options.addDeclaration({
-    help: '[Markdown Plugin] Generate Storybook compatible MDX 2 files.',
+    help: '[Markdown Plugin] Generate Storybook compatible MDX 2 files into a subfolder `docs`.',
     name: 'useStorybook',
     type: ParameterType.Boolean,
     defaultValue: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export function load(app: Application) {
     help: '[Markdown Plugin] The file name of the entry document.',
     name: 'entryDocument',
     type: ParameterType.String,
-    defaultValue: 'README.md',
+    defaultValue: 'README.mdx',
   });
 
   app.options.addDeclaration({
@@ -77,6 +77,13 @@ export function load(app: Application) {
   app.options.addDeclaration({
     help: '[Markdown Plugin] Preserve anchor casing when generating links.',
     name: 'preserveAnchorCasing',
+    type: ParameterType.Boolean,
+    defaultValue: false,
+  });
+
+  app.options.addDeclaration({
+    help: '[Markdown Plugin] Generate Storybook compatible MDX 2 files.',
+    name: 'useStorybook',
     type: ParameterType.Boolean,
     defaultValue: false,
   });

--- a/src/render-utils.ts
+++ b/src/render-utils.ts
@@ -70,7 +70,7 @@ export function registerHelpers(theme: MarkdownTheme) {
   ifShowReturnsHelper();
   ifShowTypeHierarchyHelper();
   indexSignatureTitleHelper();
-  parameterTableHelper();
+  parameterTableHelper(theme);
   objectLiteralMemberHelper(theme);
   referenceMember();
   reflectionPathHelper();
@@ -79,7 +79,7 @@ export function registerHelpers(theme: MarkdownTheme) {
   returns();
   signatureTitleHelper(theme);
   tocHelper(theme);
-  typeHelper();
+  typeHelper(theme);
   typeAndParentHelper();
   typeParameterTableHelper();
 }

--- a/src/resources/helpers/breadcrumbs.ts
+++ b/src/resources/helpers/breadcrumbs.ts
@@ -19,11 +19,14 @@ export default function (theme: MarkdownTheme) {
         ? project.name
         : `[${project.name}](${Handlebars.helpers.relativeURL(entryDocument)})`,
     );
+
     if (hasReadmeFile) {
       breadcrumbs.push(
         this.url === project.url
           ? globalsName
-          : `[${globalsName}](${Handlebars.helpers.relativeURL('modules.md')})`,
+          : `[${globalsName}](${Handlebars.helpers.relativeURL(
+              theme.useStorybook ? 'docs/app-modules.mdx' : 'modules.md',
+            )})`,
       );
     }
     const breadcrumbsOut = breadcrumb(this, this.model, breadcrumbs);

--- a/src/resources/helpers/parameter-table.ts
+++ b/src/resources/helpers/parameter-table.ts
@@ -2,8 +2,9 @@ import * as Handlebars from 'handlebars';
 import { ParameterReflection, ReflectionKind, ReflectionType } from 'typedoc';
 import { stripLineBreaks } from '../../utils';
 import { getReflectionType } from './type';
+import { MarkdownTheme } from '../../theme';
 
-export default function () {
+export default function (theme: MarkdownTheme) {
   Handlebars.registerHelper(
     'parameterTable',
 
@@ -32,13 +33,14 @@ export default function () {
 
       return table(
         this.reduce((acc: any, current: any) => parseParams(current, acc), []),
+        theme,
       );
     },
   );
 }
 
-function table(parameters: any) {
-  const showDefaults = hasDefaultValues(parameters);
+function table(parameters: any, theme: MarkdownTheme) {
+  const showDefaults = hasDefaultValues(parameters, theme);
 
   const comments = parameters.map(
     (param) => !!param.comment?.hasVisibleComponent(),
@@ -77,7 +79,7 @@ function table(parameters: any) {
     row.push(
       parameter.type
         ? Handlebars.helpers.type.call(parameter.type, 'object')
-        : getReflectionType(parameter, 'object'),
+        : getReflectionType(parameter, 'object', theme.useStorybook),
     );
 
     if (showDefaults) {
@@ -111,10 +113,13 @@ function getDefaultValue(parameter: ParameterReflection) {
     : '`undefined`';
 }
 
-function hasDefaultValues(parameters: ParameterReflection[]) {
+function hasDefaultValues(
+  parameters: ParameterReflection[],
+  theme: MarkdownTheme,
+) {
   const defaultValues = (parameters as ParameterReflection[]).map(
     (param) =>
-      param.defaultValue !== '{}' &&
+      param.defaultValue !== (theme.useStorybook ? '\\{}' : '{}') &&
       param.defaultValue !== '...' &&
       !!param.defaultValue,
   );

--- a/src/resources/helpers/reflection-title.ts
+++ b/src/resources/helpers/reflection-title.ts
@@ -25,7 +25,12 @@ export default function (theme: MarkdownTheme) {
           const typeParameters = this.model.typeParameters
             .map((typeParameter: ParameterReflection) => typeParameter.name)
             .join(', ');
-          title.push(`<${typeParameters}${shouldEscape ? '\\>' : '>'}`);
+
+          title.push(
+            `${shouldEscape ? '\\<' : '<'}${typeParameters}${
+              shouldEscape ? '\\>' : '>'
+            }`,
+          );
         }
       }
       return title.join('');

--- a/src/resources/helpers/relative-url.ts
+++ b/src/resources/helpers/relative-url.ts
@@ -2,8 +2,25 @@ import * as Handlebars from 'handlebars';
 
 import { MarkdownTheme } from '../../theme';
 
+const storybookUrlReplacements: [RegExp, string][] = [
+  [/\.mdx/, '--docs'],
+  [/\.md/, '--docs'],
+  [/[_\/\.]/g, '-'],
+];
+
 export default function (theme: MarkdownTheme) {
   Handlebars.registerHelper('relativeURL', function (url: string) {
+    if (theme.useStorybook) {
+      const transformedUrl = storybookUrlReplacements.reduce(
+        (acc, [regex, replacement]) => {
+          return acc.replace(regex, replacement);
+        },
+        url,
+      );
+
+      return '/docs/' + theme.publicPath + transformedUrl;
+    }
+
     return url
       ? theme.publicPath
         ? theme.publicPath + url

--- a/src/resources/helpers/signature-title.ts
+++ b/src/resources/helpers/signature-title.ts
@@ -27,9 +27,11 @@ export default function (theme: MarkdownTheme) {
         md.push(`**${this.name}**`);
       }
 
+      const shouldEscape = theme.useStorybook;
+
       if (this.typeParameters) {
         md.push(
-          `<${this.typeParameters
+          `${shouldEscape ? '\\<' : '<'}${this.typeParameters
             .map((typeParameter) => `\`${typeParameter.name}\``)
             .join(', ')}\\>`,
         );

--- a/src/resources/partials/mdx.hbs
+++ b/src/resources/partials/mdx.hbs
@@ -1,0 +1,11 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta
+  title="{{{model.storybookName}}}"
+  parameters=\{{
+    viewMode: 'docs',
+    previewTabs: {
+      canvas: { hidden: true },
+    },
+  }}
+/>

--- a/src/resources/templates/index.hbs
+++ b/src/resources/templates/index.hbs
@@ -1,3 +1,7 @@
+{{#if model.useStorybook}}
+{{> mdx model=model.index }}
+{{/if}}
+
 {{> header}}
 
 {{#with model.readme}}

--- a/src/resources/templates/reflection.hbs
+++ b/src/resources/templates/reflection.hbs
@@ -1,3 +1,7 @@
+{{#if model.useStorybook}}
+{{> mdx }}
+{{/if}}
+
 {{> header}}
 
 {{> title}}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -60,7 +60,7 @@ export class MarkdownTheme extends Theme {
     ) as boolean;
     const entryDocument = this.getOption('entryDocument') as string;
     this.entryDocument = this.useStorybook
-      ? 'docs/' + entryDocument
+      ? 'docs/' + entryDocument.replace(/\.md$/, '.mdx')
       : entryDocument;
     this.entryPoints = this.getOption('entryPoints') as string[];
     this.filenameSeparator = this.getOption('filenameSeparator') as string;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -42,6 +42,7 @@ export class MarkdownTheme extends Theme {
   publicPath!: string;
   preserveAnchorCasing!: boolean;
   objectLiteralTypeDeclarationStyle: ObjectLiteralDeclarationStyle;
+  useStorybook!: boolean;
   project?: ProjectReflection;
   reflection?: DeclarationReflection;
   location!: string;
@@ -53,8 +54,14 @@ export class MarkdownTheme extends Theme {
     super(renderer);
 
     // prettier-ignore
-    this.allReflectionsHaveOwnDocument = this.getOption('allReflectionsHaveOwnDocument',) as boolean;
-    this.entryDocument = this.getOption('entryDocument') as string;
+    this.useStorybook = this.getOption('useStorybook') as boolean;
+    this.allReflectionsHaveOwnDocument = this.getOption(
+      'allReflectionsHaveOwnDocument',
+    ) as boolean;
+    const entryDocument = this.getOption('entryDocument') as string;
+    this.entryDocument = this.useStorybook
+      ? 'docs/' + entryDocument
+      : entryDocument;
     this.entryPoints = this.getOption('entryPoints') as string[];
     this.filenameSeparator = this.getOption('filenameSeparator') as string;
     this.hideBreadcrumbs = this.getOption('hideBreadcrumbs') as boolean;
@@ -99,7 +106,9 @@ export class MarkdownTheme extends Theme {
     const urls: UrlMapping[] = [];
     const noReadmeFile = this.readme.endsWith('none');
     if (noReadmeFile) {
-      project.url = this.entryDocument;
+      project.url = this.useStorybook
+        ? 'docs/' + this.entryDocument
+        : this.entryDocument;
       urls.push(
         new UrlMapping(
           this.entryDocument,
@@ -118,9 +127,18 @@ export class MarkdownTheme extends Theme {
     }
     project.children?.forEach((child: Reflection) => {
       if (child instanceof DeclarationReflection) {
-        this.buildUrls(child as DeclarationReflection, urls);
+        this.buildUrls(child, urls);
       }
     });
+
+    if (this.useStorybook) {
+      (project as any).useStorybook = true;
+      (project as any).index = {
+        storybookName: 'docs/README',
+      };
+      (project as any).storybookName = 'docs/app-modules';
+    }
+
     return urls;
   }
 
@@ -149,11 +167,21 @@ export class MarkdownTheme extends Theme {
     } else if (reflection.parent) {
       this.applyAnchorUrl(reflection, reflection.parent, true);
     }
+
+    if (this.useStorybook) {
+      (reflection as any).useStorybook = true;
+
+      const storybookName = reflection.url?.replace(/\.mdx$/, '');
+      (reflection as any).storybookName = storybookName;
+    }
+
     return urls;
   }
 
   toUrl(mapping: any, reflection: DeclarationReflection) {
-    return mapping.directory + '/' + this.getUrl(reflection) + '.md';
+    const fileEnding = this.useStorybook ? '.mdx' : '.md';
+
+    return mapping.directory + '/' + this.getUrl(reflection) + fileEnding;
   }
 
   getUrl(reflection: Reflection, relative?: Reflection): string {
@@ -323,31 +351,31 @@ export class MarkdownTheme extends Theme {
       {
         kind: [ReflectionKind.Module],
         isLeaf: false,
-        directory: 'modules',
+        directory: this.useStorybook ? 'docs/modules' : 'modules',
         template: this.getReflectionTemplate(),
       },
       {
         kind: [ReflectionKind.Namespace],
         isLeaf: false,
-        directory: 'modules',
+        directory: this.useStorybook ? 'docs/modules' : 'modules',
         template: this.getReflectionTemplate(),
       },
       {
         kind: [ReflectionKind.Enum],
         isLeaf: false,
-        directory: 'enums',
+        directory: this.useStorybook ? 'docs/enums' : 'enums',
         template: this.getReflectionTemplate(),
       },
       {
         kind: [ReflectionKind.Class],
         isLeaf: false,
-        directory: 'classes',
+        directory: this.useStorybook ? 'docs/classes' : 'classes',
         template: this.getReflectionTemplate(),
       },
       {
         kind: [ReflectionKind.Interface],
         isLeaf: false,
-        directory: 'interfaces',
+        directory: this.useStorybook ? 'docs/interfaces' : 'interfaces',
         template: this.getReflectionTemplate(),
       },
       ...(this.allReflectionsHaveOwnDocument
@@ -355,19 +383,19 @@ export class MarkdownTheme extends Theme {
             {
               kind: [ReflectionKind.TypeAlias],
               isLeaf: true,
-              directory: 'types',
+              directory: this.useStorybook ? 'docs/types' : 'types',
               template: this.getReflectionMemberTemplate(),
             },
             {
               kind: [ReflectionKind.Variable],
               isLeaf: true,
-              directory: 'variables',
+              directory: this.useStorybook ? 'docs/variables' : 'variables',
               template: this.getReflectionMemberTemplate(),
             },
             {
               kind: [ReflectionKind.Function],
               isLeaf: true,
-              directory: 'functions',
+              directory: this.useStorybook ? 'docs/functions' : 'functions',
               template: this.getReflectionMemberTemplate(),
             },
           ]
@@ -396,6 +424,6 @@ export class MarkdownTheme extends Theme {
   }
 
   get globalsFile() {
-    return 'modules.md';
+    return this.useStorybook ? 'docs/app-modules.mdx' : 'modules.md';
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,12 +14,23 @@ export function formatContents(contents: string) {
   );
 }
 
-export function escapeChars(str: string) {
-  return str
-    .replace(/>/g, '\\>')
-    .replace(/_/g, '\\_')
-    .replace(/`/g, '\\`')
-    .replace(/\|/g, '\\|');
+export function escapeChars(str: string, useStorybookSyntax = false) {
+  const replacements: [RegExp, string][] = [
+    [/>/g, '\\>'],
+    [/_/g, '\\_'],
+    [/`/g, '\\`'],
+    [/\|/g, '\\|'],
+    ...((useStorybookSyntax
+      ? [
+          [/</g, '\\<'],
+          [/{/g, '\\{'],
+        ]
+      : []) as [RegExp, string][]),
+  ];
+
+  return replacements.reduce((acc, [regex, replacement]) => {
+    return acc.replace(regex, replacement);
+  }, str);
 }
 
 export function memberSymbol(


### PR DESCRIPTION
This PR adds the option `useStorybook` which can be used to generate mdx 2 files instead of markdown to use with storybook.